### PR TITLE
Add functionality to fetch all metrics and metrics for calendar days

### DIFF
--- a/Infrastructure/Repository/CalendarDayRepository.cs
+++ b/Infrastructure/Repository/CalendarDayRepository.cs
@@ -23,6 +23,25 @@ public class CalendarDayRepository : ICalendarDayRepository
 
         return CreateCalendarDay(state!, sql, new { userId, date });
     }
+    
+    public async Task<List<CalendarDay>> GetByDateRange(Guid userId, DateTimeOffset from, DateTimeOffset to)
+    {
+        var sql = @"SELECT ""State"" FROM ""CalendarDay"" WHERE ""UserId"" = @userId AND CAST(""Date"" AS DATE) >= CAST(@from AS DATE) AND CAST(""Date"" AS DATE) <= CAST(@to AS DATE)";
+        var states = await _db.QueryAsync<string>(sql, new { userId, from, to });
+
+        sql = @"SELECT * FROM ""CalendarDay"" WHERE ""UserId"" = @userId AND CAST(""Date"" AS DATE) >= CAST(@from AS DATE) AND CAST(""Date"" AS DATE) <= CAST(@to AS DATE)";
+
+        var parameters = new { userId, from, to };
+        var calendarDays = new List<CalendarDay>();
+
+        foreach (var state in states)
+        {
+            var calendarDay = CreateCalendarDay(state!, sql, parameters);
+            calendarDays.Add(calendarDay);
+        }
+
+        return calendarDays;
+    }
 
     public async Task<CalendarDay?> GetById(Guid calendarDayId)
     {

--- a/Infrastructure/Repository/Interface/ICalendarDayRepository.cs
+++ b/Infrastructure/Repository/Interface/ICalendarDayRepository.cs
@@ -5,5 +5,6 @@ namespace Infrastructure.Repository.Interface;
 public interface ICalendarDayRepository
 {
     Task<CalendarDay?> GetByDate(Guid userId, DateTimeOffset dateTimeOffset);
+    Task<List<CalendarDay>> GetByDateRange(Guid userId, DateTimeOffset from, DateTimeOffset to);
     Task<CalendarDay?> GetById(Guid calendarDayId);
 }

--- a/Infrastructure/Repository/Interface/IMetricRepository.cs
+++ b/Infrastructure/Repository/Interface/IMetricRepository.cs
@@ -1,10 +1,14 @@
-﻿using Models.Dto.Metrics;
+﻿using Models;
+using Models.Days;
+using Models.Dto.Metrics;
 using Models.Util;
 
 namespace Infrastructure.Repository.Interface;
 
 public interface IMetricRepository
 {
+    Task<List<Metrics>> GetAllMetrics();
+    Task<IEnumerable<CalendarDay>> GetMetricsForCalendarDays(Guid userId, DateTimeOffset fromDate, DateTimeOffset toDate);
     Task<ICollection<CalendarDayMetric>> Get(Guid userId, DateTimeOffset date);
     Task UploadMetricForADay(Guid calendarDayId, List<MetricRegisterMetricDto> metrics);
 }

--- a/Models/Dto/Metrics/MetricsDto.cs
+++ b/Models/Dto/Metrics/MetricsDto.cs
@@ -4,5 +4,5 @@ public class MetricsDto
 {
     public Guid Id { get; set; }
     public required string Name { get; set; }
-    public List<MetricValue> Values { get; set; } = new();
+    public List<ValueDto> Values { get; set; } = new();
 }

--- a/Models/Dto/Metrics/ValueDto.cs
+++ b/Models/Dto/Metrics/ValueDto.cs
@@ -1,0 +1,8 @@
+﻿namespace Models.Dto.Metrics;
+
+public class ValueDto
+{
+    public Guid Id { get; set; }
+    /// <example> "Mild" "Severe"... </example>
+    public string Name { get; set; } = null!;
+}

--- a/Vital/Controllers/MetricController.cs
+++ b/Vital/Controllers/MetricController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Models.Dto.Cycle;
 using Models.Dto.Metrics;
@@ -14,13 +15,38 @@ public class MetricController : BaseController
     // TODO? Add interface
     private readonly IMetricService _metricService;
     private readonly CurrentContext _currentContext;
+    private readonly IMapper _mapper;
 
-    public MetricController(IMetricService metricService, CurrentContext currentContext)
+    public MetricController(IMetricService metricService, CurrentContext currentContext, IMapper mapper)
     {
         _metricService = metricService;
         _currentContext = currentContext;
+        _mapper = mapper;
     }
 
+    [AllowAnonymous]
+    [HttpGet("Values")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetAllValues()
+    {
+        var list = await _metricService.GetAllMetrics();
+        
+        return Ok(_mapper.Map<List<MetricsDto>>(list));
+    }
+
+    [HttpGet("calendar")]
+    public async Task<IActionResult> GetMetricsForCalendarDays([FromQuery] DateTimeOffset fromDate, [FromQuery]
+        DateTimeOffset toDate)
+    {
+        if (toDate < fromDate)
+        {
+            throw new Exception("To date can't be smaller");
+        }
+        var list = await _metricService.GetMetricsForCalendarDays(_currentContext.UserId!.Value, fromDate, toDate);
+        
+        return Ok(list);
+    }
+    
     /// <summary>
     /// Gets the metrics for a day for the current user (based on the token).
     /// </summary>

--- a/Vital/Core/Services/Interfaces/IMetricService.cs
+++ b/Vital/Core/Services/Interfaces/IMetricService.cs
@@ -1,4 +1,6 @@
-﻿using Models.Dto.Cycle;
+﻿using Models;
+using Models.Days;
+using Models.Dto.Cycle;
 using Models.Dto.Metrics;
 using Models.Util;
 
@@ -6,6 +8,9 @@ namespace Vital.Core.Services.Interfaces;
 
 public interface IMetricService
 {
+    Task<List<Metrics>> GetAllMetrics();
+    Task<IEnumerable<CalendarDay>> GetMetricsForCalendarDays(Guid userId, DateTimeOffset fromDate,
+        DateTimeOffset toDate);
     Task<ICollection<CalendarDayMetric>> Get(Guid userId, DateTimeOffset date);
     Task<CalendarDayDto> UploadMetricForADay(Guid userId, List<MetricRegisterMetricDto> metricsDto, DateTimeOffset dateTimeOffset);
 }

--- a/Vital/Core/Services/MetricService.cs
+++ b/Vital/Core/Services/MetricService.cs
@@ -1,5 +1,7 @@
 ﻿using AutoMapper;
 using Infrastructure.Repository.Interface;
+using Models;
+using Models.Days;
 using Models.Dto.Cycle;
 using Models.Dto.Metrics;
 using Models.Util;
@@ -20,6 +22,16 @@ public class MetricService : IMetricService
         _metricRepository = metricRepository;
         _calendarDayRepository = calendarDayRepository;
         _mapper = mapper;
+    }
+
+    public async Task<List<Metrics>> GetAllMetrics()
+    {
+        return await _metricRepository.GetAllMetrics();
+    }
+    
+    public async Task<IEnumerable<CalendarDay>> GetMetricsForCalendarDays(Guid userId, DateTimeOffset fromDate, DateTimeOffset toDate)
+    {
+        return await _metricRepository.GetMetricsForCalendarDays(userId, fromDate, toDate);
     }
 
     public async Task<ICollection<CalendarDayMetric>> Get(Guid userId, DateTimeOffset date)

--- a/Vital/Extension/Mapping/MappingProfile.cs
+++ b/Vital/Extension/Mapping/MappingProfile.cs
@@ -25,5 +25,6 @@ public class MappingProfile : Profile
         CreateMap<Metrics, MetricsDto>();
         CreateMap<MetricValue, MetricValueDto>();
         CreateMap<CalendarDayMetric, CalendarDayMetricDto>();
+        CreateMap<MetricValue, ValueDto>();
     }
 }


### PR DESCRIPTION
New features were added to fetch all the Metric values and to retrieve metrics for specific calendar dates. Added new methods 'GetAllMetrics' and 'GetMetricsForCalendarDays' in IMetricRepository, IMetricService and implementations. Updated 'MetricController' with endpoints for retrieving these metrics. Listener can now request metrics related to certain calendar day ranges. Also, MappingProfile updated with map creation for MetricValue to ValueDto. This enhancement will provide more flexibility when dealing with metrics and their relationship to calendar days.