### PR TITLE
Fix URL path in account service

### DIFF
--- a/Vital-Frontend/src/app/services/account.service.ts
+++ b/Vital-Frontend/src/app/services/account.service.ts
@@ -54,6 +54,6 @@ export default class AccountService {
 
   public async isValidTokenForUser(dto: VerifyRequestDto): Promise<boolean> {
     const encodedToken = encodeURIComponent(dto.token);
-    return await this.httpService.get<boolean>(`$/Identity/Auth/valid-token?userId=${dto.userId}&token=${encodedToken}`) ?? false;
+    return await this.httpService.get<boolean>(`/Identity/Auth/valid-token?userId=${dto.userId}&token=${encodedToken}`) ?? false;
   }
 }


### PR DESCRIPTION
The URL path in the account service was incorrectly prefixed with a dollar sign. This commit removes that unnecessary and disruptive prefix and aims to restore the correct functionality of the isValidTokenForUser method.